### PR TITLE
sdcardfs: fix space leak

### DIFF
--- a/fs/sdcardfs/dentry.c
+++ b/fs/sdcardfs/dentry.c
@@ -185,7 +185,13 @@ static void sdcardfs_canonical_path(const struct path *path,
 	sdcardfs_get_real_lower(path->dentry, actual_path);
 }
 
+static int sdcardfs_d_delete(const struct dentry * dentry)
+{
+	return dentry->d_inode && !S_ISDIR(dentry->d_inode->i_mode);
+}
+
 const struct dentry_operations sdcardfs_ci_dops = {
+	.d_delete	= sdcardfs_d_delete,
 	.d_revalidate	= sdcardfs_d_revalidate,
 	.d_release	= sdcardfs_d_release,
 	.d_hash	= sdcardfs_hash_ci,


### PR DESCRIPTION
Don't keep looked up dentries around because there's no notification
when the lowerfs unlinks an inode, to collect the upper dentry cache so
the lower inode reference can be released and the storage space
released.

This effectively disables the dcache lookups but it should still be much
faster than fuse sdcardfs.

The alternative is to add a notification mechanism to keep two separate
dcache layers in sync which isn't trivial, or stop ever touching the
lower fs and remove that path.replace from VolumeInfo.java.